### PR TITLE
fix: 'translate' key missing in HTMLAttributes interface

### DIFF
--- a/packages/schema/src/html-attributes.ts
+++ b/packages/schema/src/html-attributes.ts
@@ -11,6 +11,14 @@ export interface HtmlAttributes {
    */
   dir?: 'ltr' | 'rtl' | 'auto'
   /**
+   * The translate global attribute is an enumerated attribute that is used to specify whether an element's 
+   * translatable attribute values and its Text node children should be translated when the page is localized, 
+   * or whether to leave them unchanged.
+   * 
+   * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/translate
+   */
+  translate?: 'yes' | 'no'
+  /**
    * The class global attribute is a space-separated list of the case-sensitive classes of the element.
    *
    * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Global_attributes/class


### PR DESCRIPTION
<!-- DO NOT INGORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

This is important e.g. for Progressive Web Apps (PWAs) where you want to avoid translation suggestions from the browser. The problem occurs in Nuxt 3 `app.head.htmlAttrs`. Adding the `translate` key works, but it creates a type error.

### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
