### PR TITLE
fix: prefer `name` for 'twitter:*' meta

### DIFF
--- a/packages/schema/src/meta.ts
+++ b/packages/schema/src/meta.ts
@@ -32,29 +32,7 @@ export type MetaNames =
 'default-style' |
 'x-ua-compatible' |
 'refresh' |
-'keywords'
-
-export type MetaProperties = 'og:url' |
-'og:title' |
-'og:description' |
-'og:type' |
-'og:locale' |
-'og:locale:alternate' |
-'og:determiner' |
-'og:site:name' |
-'og:video' |
-'og:video:url' |
-'og:video:secure_url' |
-'og:video:type' |
-'og:video:width' |
-'og:video:height' |
-'og:image' |
-'og:image:url' |
-'og:image:secure_url' |
-'og:image:type' |
-'og:image:width' |
-'og:image:height' |
-'fb:app:id' |
+'keywords' |
 'twitter:card' |
 'twitter:title' |
 'twitter:description' |
@@ -81,6 +59,28 @@ export type MetaProperties = 'og:url' |
 'twitter:label:1' |
 'twitter:data:2' |
 'twitter:label:2'
+
+export type MetaProperties = 'og:url' |
+'og:title' |
+'og:description' |
+'og:type' |
+'og:locale' |
+'og:locale:alternate' |
+'og:determiner' |
+'og:site:name' |
+'og:video' |
+'og:video:url' |
+'og:video:secure_url' |
+'og:video:type' |
+'og:video:width' |
+'og:video:height' |
+'og:image' |
+'og:image:url' |
+'og:image:secure_url' |
+'og:image:type' |
+'og:image:width' |
+'og:image:height' |
+'fb:app:id'
 
 export interface Meta {
   /**

--- a/packages/zhead/src/inferSeoMetaTags.ts
+++ b/packages/zhead/src/inferSeoMetaTags.ts
@@ -22,11 +22,11 @@ export function inferSeoMetaTags<T extends HeadTag[]>(tags: T) {
     })
   }
   // if we have an image, add twitter:card if missing
-  if (tags.find(t => t.tag === 'meta' && t.props.property === 'og:image') && !tags.find(t => t.tag === 'meta' && t.props.property === 'twitter:card')) {
+  if (tags.find(t => t.tag === 'meta' && t.props.property === 'og:image') && !tags.find(t => t.tag === 'meta' && t.props.name === 'twitter:card')) {
     tags.push({
       tag: 'meta',
       props: {
-        property: 'twitter:card',
+        name: 'twitter:card',
         content: 'summary_large_image',
       },
     })

--- a/packages/zhead/src/transforms/keyCasing.ts
+++ b/packages/zhead/src/transforms/keyCasing.ts
@@ -1,8 +1,9 @@
-export const PropertyPrefixKeys = /^(og|twitter|fb)/
+export const PropertyPrefixKeys = /^(og|fb)/
+export const ColonPrefixKeys = /^(og|twitter|fb)/
 
 export function fixKeyCase(key: string) {
   key = key.replace(/([A-Z])/g, '-$1').toLowerCase()
-  if (PropertyPrefixKeys.test(key)) {
+  if (ColonPrefixKeys.test(key)) {
     key = key
       .replace('secure-url', 'secure_url')
       .replace(/-/g, ':')

--- a/test/schema/meta.test.ts
+++ b/test/schema/meta.test.ts
@@ -58,7 +58,7 @@ describe('metatags', () => {
           content: 'https://example.com/image.jpg',
         },
         {
-          property: 'twitter:card',
+          name: 'twitter:card',
           content: 'summary_large_image',
         },
         {
@@ -81,7 +81,7 @@ describe('metatags', () => {
           },
           {
             "content": "summary_large_image",
-            "property": "twitter:card",
+            "name": "twitter:card",
           },
           {
             "content": "origin-when-cross-origin",

--- a/test/zhead/unpackMeta.test.ts
+++ b/test/zhead/unpackMeta.test.ts
@@ -409,107 +409,107 @@ describe('unpackMeta', () => {
         },
         {
           "content": "summary",
-          "property": "twitter:card",
+          "name": "twitter:card",
         },
         {
           "content": "my title",
-          "property": "twitter:title",
+          "name": "twitter:title",
         },
         {
           "content": "my description",
-          "property": "twitter:description",
+          "name": "twitter:description",
         },
         {
           "content": "https://example.com/image.png",
-          "property": "twitter:image",
+          "name": "twitter:image",
         },
         {
           "content": "my image",
-          "property": "twitter:image:alt",
+          "name": "twitter:image:alt",
         },
         {
           "content": "@my_site",
-          "property": "twitter:site",
+          "name": "twitter:site",
         },
         {
           "content": "1234567890",
-          "property": "twitter:site:id",
+          "name": "twitter:site:id",
         },
         {
           "content": "@my_creator",
-          "property": "twitter:creator",
+          "name": "twitter:creator",
         },
         {
           "content": "1234567890",
-          "property": "twitter:creator:id",
+          "name": "twitter:creator:id",
         },
         {
           "content": "https://example.com/video.mp4",
-          "property": "twitter:player",
+          "name": "twitter:player",
         },
         {
           "content": "1280",
-          "property": "twitter:player:width",
+          "name": "twitter:player:width",
         },
         {
           "content": "720",
-          "property": "twitter:player:height",
+          "name": "twitter:player:height",
         },
         {
           "content": "https://example.com/video.mp4",
-          "property": "twitter:player:stream",
+          "name": "twitter:player:stream",
         },
         {
           "content": "my app",
-          "property": "twitter:app:name:iphone",
+          "name": "twitter:app:name:iphone",
         },
         {
           "content": "1234567890",
-          "property": "twitter:app:id:iphone",
+          "name": "twitter:app:id:iphone",
         },
         {
           "content": "https://example.com",
-          "property": "twitter:app:url:iphone",
+          "name": "twitter:app:url:iphone",
         },
         {
           "content": "my app",
-          "property": "twitter:app:name:ipad",
+          "name": "twitter:app:name:ipad",
         },
         {
           "content": "1234567890",
-          "property": "twitter:app:id:ipad",
+          "name": "twitter:app:id:ipad",
         },
         {
           "content": "https://example.com",
-          "property": "twitter:app:url:ipad",
+          "name": "twitter:app:url:ipad",
         },
         {
           "content": "my app",
-          "property": "twitter:app:name:googleplay",
+          "name": "twitter:app:name:googleplay",
         },
         {
           "content": "1234567890",
-          "property": "twitter:app:id:googleplay",
+          "name": "twitter:app:id:googleplay",
         },
         {
           "content": "https://example.com",
-          "property": "twitter:app:url:googleplay",
+          "name": "twitter:app:url:googleplay",
         },
         {
           "content": "my data",
-          "property": "twitter:data1",
+          "name": "twitter:data1",
         },
         {
           "content": "my label",
-          "property": "twitter:label1",
+          "name": "twitter:label1",
         },
         {
           "content": "my data",
-          "property": "twitter:data2",
+          "name": "twitter:data2",
         },
         {
           "content": "my label",
-          "property": "twitter:label2",
+          "name": "twitter:label2",
         },
       ]
     `)


### PR DESCRIPTION
### Description

It's not working if the 'twitter:*' card properties are defined with the wrong attribute.
ref: https://developer.twitter.com/en/docs/twitter-for-websites/cards/guides/getting-started

- [x] change schema
- [x] implement fix
- [x] update tests

### Linked Issues

### Additional context
- also affecting nuxt v3.1.0/3.1.1 with the new Composable: `useSeoMeta` and `useServerSeoMeta` for twitter meta tags. 
The `<meta>` tag is rendered using `property="twitter:*"` attribute, but must use `name="twitter:*"`.

Current, not working:
![image1](https://user-images.githubusercontent.com/10864443/215357042-f6a84185-acb4-4826-a155-cd93efc933aa.png)

Should, working:
![image2](https://user-images.githubusercontent.com/10864443/215357050-89444fe9-9e94-417d-b151-4da42e73ada1.png)
