### PR TITLE
fix: `sizes` attribute

### DIFF
--- a/src/link.ts
+++ b/src/link.ts
@@ -157,7 +157,7 @@ export interface LinkBase {
    *
    * @see https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#attr-sizes
    */
-  sizes?: 'any' | '16x16x' | '32x32' | '64x64' | '180x180' | (string & Record<never, never>)
+  sizes?: 'any' | '16x16' | '32x32' | '64x64' | '180x180' | (string & Record<never, never>)
   /**
    * The title attribute has special semantics on the `<link>` element.
    * When used on a `<link rel="stylesheet">` it defines a default or an alternate stylesheet.


### PR DESCRIPTION
<!-- DO NOT INGORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
According to MDN, the value should be `<width in pixels>x<height in pixels>`.
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/link#sizes

This has been corrected as it appears to be a typo.

### Linked Issues

none

### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
