### PR TITLE
fix: remove CSP navigate-to

### DIFF
--- a/src/metaFlat.ts
+++ b/src/metaFlat.ts
@@ -773,7 +773,6 @@ export interface MetaFlat {
     sandbox: string
     formAction: string
     frameAncestors: string
-    navigateTo: string
     reportUri: string
     reportTo: string
     requireSriFor: string

--- a/src/metaFlat.ts
+++ b/src/metaFlat.ts
@@ -773,7 +773,8 @@ export interface MetaFlat {
     sandbox: string
     formAction: string
     frameAncestors: string
-    //navigateTo: string
+    // See https://github.com/w3c/webappsec-csp/pull/564
+    // navigateTo: string
     reportUri: string
     reportTo: string
     requireSriFor: string

--- a/src/metaFlat.ts
+++ b/src/metaFlat.ts
@@ -773,6 +773,7 @@ export interface MetaFlat {
     sandbox: string
     formAction: string
     frameAncestors: string
+    //navigateTo: string
     reportUri: string
     reportTo: string
     requireSriFor: string


### PR DESCRIPTION
<!-- DO NOT INGORE THE TEMPLATE!

Thank you for contributing!

Before submitting the PR, please make sure you do the following:

- Read the [Contributing Guide](https://github.com/antfu/contribute).
- Check that there isn't already a PR that solves the problem the same way to avoid creating a duplicate.
- Provide a description in this PR that addresses **what** the PR is solving, or reference the issue that it solves (e.g. `fixes #123`).
- Ideally, include relevant tests that fail without this PR but pass with it.

-->

### Description

<!-- Please insert your description here and provide especially info about the "what" this PR is solving -->
This PR just removes navigateTo from the TypeScript type annotation due to the directive being removed from the official CSP spec as seen [here](https://github.com/w3c/webappsec-csp/pull/564) after a security concern was discovered involving cross-origin data leaks. This comments it out so people won't try to use it (as it isn't functional), and in case a new navigate-to implementation would arrive that takes care of the previous one's issues this PR makes it extremely easy to return the directive.
### Linked Issues


### Additional context

<!-- e.g. is there anything you'd like reviewers to focus on? -->
