### PR TITLE
fix: deprecate non-existent twitter properties

### DIFF
--- a/src/metaFlat.ts
+++ b/src/metaFlat.ts
@@ -580,20 +580,25 @@ export interface MetaFlat {
      * Equivalent to twitter:image
      */
     url: string
+
     /**
      * MIME type of the image.
+     * @deprecated Twitter removed this property from their card specification.
      */
     type?: 'image/jpeg' | 'image/gif' | 'image/png'
 
     /**
      * Width of image in pixels. Specify height and width for your image to ensure that the image loads properly the first time it's shared.
+     * @deprecated Twitter removed this property from their card specification.
      */
     width?: string | number
 
     /**
      * Height of image in pixels. Specify height and width for your image to ensure that the image loads properly the first time it's shared.
+     * @deprecated Twitter removed this property from their card specification.
      */
     height?: string | number
+
     /**
      * A description of what is in the image (not a caption). If the page specifies an og:image, it should specify og:image:alt.
      */
@@ -606,6 +611,8 @@ export interface MetaFlat {
    * Note: This is not officially documented.
    *
    * Same as `og:image:width`
+   *
+   * @deprecated Twitter removed this property from their card specification.
    */
   twitterImageWidth: string | number
   /**
@@ -614,6 +621,8 @@ export interface MetaFlat {
    * Note: This is not officially documented.
    *
    * Same as `og:image:height`
+   *
+   * @deprecated Twitter removed this property from their card specification.
    */
   twitterImageHeight: string | number
   /**
@@ -622,8 +631,11 @@ export interface MetaFlat {
    * Note: This is not officially documented.
    *
    * Same as `og:image:type`
+   *
+   * @deprecated Twitter removed this property from their card specification.
    */
   twitterImageType: 'image/jpeg' | 'image/gif' | 'image/png'
+
   /**
    * A text description of the image conveying the essential nature of an image to users who are visually impaired.
    * Maximum 420 characters.
@@ -744,18 +756,34 @@ export interface MetaFlat {
   twitterAppUrlGoogleplay: string
   /**
    * Top customizable data field, can be a relatively short string (ie “$3.99”)
+   *
+   * Used by Slack.
+   *
+   * @see https://api.slack.com/reference/messaging/link-unfurling#classic_unfurl
    */
   twitterData1: string
   /**
    * Customizable label or units for the information in twitter:data1 (best practice: use all caps)
+   *
+   * Used by Slack.
+   *
+   * @see https://api.slack.com/reference/messaging/link-unfurling#classic_unfurl
    */
   twitterLabel1: string
   /**
    * Bottom customizable data field, can be a relatively short string (ie “Seattle, WA”)
+   *
+   * Used by Slack.
+   *
+   * @see https://api.slack.com/reference/messaging/link-unfurling#classic_unfurl
    */
   twitterData2: string
   /**
    * Customizable label or units for the information in twitter:data2 (best practice: use all caps)
+   *
+   * Used by Slack.
+   *
+   * @see https://api.slack.com/reference/messaging/link-unfurling#classic_unfurl
    */
   twitterLabel2: string
 


### PR DESCRIPTION
### Description

Those properties should not exist. `width`/`height` were specified in the Twitter docs up until 2015 or so, but are not supported anymore. I do not find any references for `data` and `label` as well.

### Linked Issues

n/a

### Additional context

Would you create a `v3` branch I can target this PR against?
I'm working on related changes in `unhead`.