### PR TITLE
feat: add fediverse:creator meta tag and fix twitter tag categorization

### DIFF
--- a/packages/db/src/meta/en/fediverse:creator.ts
+++ b/packages/db/src/meta/en/fediverse:creator.ts
@@ -1,0 +1,28 @@
+import type { MetaSchema } from '../../metaFlat'
+
+export const fediverseCreator: MetaSchema = {
+  name: 'fediverse:creator',
+  key: 'name',
+  color: '#6364FF',
+  tags: 'social-share',
+  description: 'Indicates the Fediverse account of the content creator or author for a webpage. Used by Mastodon and other Fediverse platforms to attribute content to creators.',
+  tips: [
+    {
+      title: 'Use a Full Fediverse Handle',
+      description: 'Include the full handle with the "@" symbol and the instance domain, e.g. "@user@mastodon.social".',
+    },
+    {
+      title: 'Pair with rel="me" Link',
+      description: 'For verification, also add a <link rel="me" href="https://mastodon.social/@user" /> tag pointing to the Fediverse profile.',
+    },
+  ],
+  examples: [
+    {
+      value: '@gargron@mastodon.social',
+      description: 'Specifies the Fediverse creator as the user @gargron on mastodon.social.',
+    },
+  ],
+  documentation: [
+    'https://blog.joinmastodon.org/2024/07/highlighting-journalism-on-mastodon/',
+  ],
+}

--- a/packages/db/src/meta/en/twitter:app:id:googleplay.ts
+++ b/packages/db/src/meta/en/twitter:app:id:googleplay.ts
@@ -3,6 +3,7 @@ import type { MetaSchema } from '../../metaFlat'
 export const twitterAppIdGoogleplay: MetaSchema = {
   name: 'twitter:app:id:googleplay',
   key: 'name',
+  type: 'twitter',
   color: '#B4C1D7',
   tags: 'social-share',
   description: 'Specifies the Google Play app ID associated with the website for use on Twitter.',

--- a/packages/db/src/meta/en/twitter:app:id:ipad.ts
+++ b/packages/db/src/meta/en/twitter:app:id:ipad.ts
@@ -3,6 +3,7 @@ import type { MetaSchema } from '../../metaFlat'
 export const twitterAppIdIpad: MetaSchema = {
   name: 'twitter:app:id:ipad',
   key: 'name',
+  type: 'twitter',
   color: '#FFB30D',
   tags: 'social-share',
   description: 'Specifies the unique identifier for the iPad-specific app associated with the web page, allowing the app to be deep-linked when shared on Twitter.',

--- a/packages/db/src/meta/en/twitter:app:id:iphone.ts
+++ b/packages/db/src/meta/en/twitter:app:id:iphone.ts
@@ -3,6 +3,7 @@ import type { MetaSchema } from '../../metaFlat'
 export const twitterAppIdIphone: MetaSchema = {
   name: 'twitter:app:id:iphone',
   key: 'name',
+  type: 'twitter',
   color: '#00ACED',
   tags: 'social-share',
   description: 'Specifies the Twitter App ID for iOS devices. This meta tag is used to associate your iOS app with your website, allowing users to easily navigate between your website and app.',

--- a/packages/db/src/meta/en/twitter:app:name:ipad.ts
+++ b/packages/db/src/meta/en/twitter:app:name:ipad.ts
@@ -3,6 +3,7 @@ import type { MetaSchema } from '../../metaFlat'
 export const twitterAppNameIpad: MetaSchema = {
   name: 'twitter:app:name:ipad',
   key: 'name',
+  type: 'twitter',
   color: '#FF3366',
   tags: 'social-share',
   description: 'Specifies the name of the iPad-optimized app that should be used to open the webpage when shared on Twitter.',

--- a/packages/db/src/meta/en/twitter:app:name:iphone.ts
+++ b/packages/db/src/meta/en/twitter:app:name:iphone.ts
@@ -3,6 +3,7 @@ import type { MetaSchema } from '../../metaFlat'
 export const twitterAppNameIphone: MetaSchema = {
   name: 'twitter:app:name:iphone',
   key: 'name',
+  type: 'twitter',
   color: '#1DA1F2',
   tags: 'social-share',
   description: 'Specifies the name of your iPhone app if you have one associated with your website. This meta tag is used for Twitter sharing on iOS devices and allows users to open your app directly from a tweet.',

--- a/packages/db/src/meta/en/twitter:app:url:googleplay.ts
+++ b/packages/db/src/meta/en/twitter:app:url:googleplay.ts
@@ -3,6 +3,7 @@ import type { MetaSchema } from '../../metaFlat'
 export const twitterAppUrlGoogleplay: MetaSchema = {
   name: 'twitter:app:url:googleplay',
   key: 'name',
+  type: 'twitter',
   color: '#29B6F6',
   tags: 'social-share',
   description: 'Specifies the custom URL scheme for an Android app on the Google Play Store. It allows users to open the app directly from a link in a Twitter post on Android devices.',

--- a/packages/db/src/meta/en/twitter:app:url:ipad.ts
+++ b/packages/db/src/meta/en/twitter:app:url:ipad.ts
@@ -3,6 +3,7 @@ import type { MetaSchema } from '../../metaFlat'
 export const twitterAppUrlIpad: MetaSchema = {
   name: 'twitter:app:url:ipad',
   key: 'name',
+  type: 'twitter',
   description: 'The URL to open your app to a specific page in the Twitter app on iPad.',
   tags: ['social-share'],
   color: '#FFCDD2',

--- a/packages/db/src/meta/en/twitter:app:url:iphone.ts
+++ b/packages/db/src/meta/en/twitter:app:url:iphone.ts
@@ -3,6 +3,7 @@ import type { MetaSchema } from '../../metaFlat'
 export const twitterAppUrlIphone: MetaSchema = {
   name: 'twitter:app:url:iphone',
   key: 'name',
+  type: 'twitter',
   color: '#0390fc',
   tags: 'social-share',
   description: 'Specifies the deep link URL for the iOS app associated with the website when shared on Twitter using an iPhone.',

--- a/packages/db/src/meta/en/twitter:card.ts
+++ b/packages/db/src/meta/en/twitter:card.ts
@@ -3,6 +3,7 @@ import type { MetaSchema } from '../../metaFlat'
 export const twitterCard: MetaSchema = {
   name: 'twitter:card',
   key: 'name',
+  type: 'twitter',
   color: '#1DA1F2',
   tags: 'social-share',
   description: 'Specifies the card type to be used when a link to a web page is shared on Twitter. The card type determines how the shared content appears on Twitter.',

--- a/packages/db/src/meta/en/twitter:creator.ts
+++ b/packages/db/src/meta/en/twitter:creator.ts
@@ -3,6 +3,7 @@ import type { MetaSchema } from '../../metaFlat'
 export const twitterCreator: MetaSchema = {
   name: 'twitter:creator',
   key: 'name',
+  type: 'twitter',
   color: '#00acee',
   tags: 'social-share',
   description: 'Indicates the Twitter username of the content creator or author for a webpage.',

--- a/packages/db/src/meta/en/twitter:creator:id.ts
+++ b/packages/db/src/meta/en/twitter:creator:id.ts
@@ -3,6 +3,7 @@ import type { MetaSchema } from '../../metaFlat'
 export const twitterCreatorId: MetaSchema = {
   name: 'twitter:creator:id',
   key: 'name',
+  type: 'twitter',
   color: '#85c1e9',
   tags: 'social-share',
   description: 'Specifies the Twitter user ID of the content creator or author. This meta tag helps Twitter display the correct Twitter card when the content is shared on the platform.',

--- a/packages/db/src/meta/en/twitter:data1.ts
+++ b/packages/db/src/meta/en/twitter:data1.ts
@@ -3,6 +3,7 @@ import type { MetaSchema } from '../../metaFlat'
 export const twitterData1: MetaSchema = {
   name: 'twitter:data1',
   key: 'name',
+  type: 'twitter',
   color: '#00ACEE',
   tags: 'social-share',
   description: 'A data field used by Twitter Cards to display additional information in a tweet containing a URL to a web page. The "twitter:data1" meta tag allows you to specify the value for the data field, which can be used to provide context or important details about the shared content.',

--- a/packages/db/src/meta/en/twitter:data2.ts
+++ b/packages/db/src/meta/en/twitter:data2.ts
@@ -3,6 +3,7 @@ import type { MetaSchema } from '../../metaFlat'
 export const twitterData2: MetaSchema = {
   name: 'twitter:data2',
   key: 'name',
+  type: 'twitter',
   color: '#FF00FF',
   tags: 'social-share',
   description: 'A custom meta tag for specifying a secondary value associated with the shared content on Twitter. This meta tag is used in conjunction with the "twitter:card" meta tag to provide additional information or context about the shared content.',

--- a/packages/db/src/meta/en/twitter:description.ts
+++ b/packages/db/src/meta/en/twitter:description.ts
@@ -2,7 +2,7 @@ import type { MetaSchema } from '../../metaFlat'
 
 export const twitterDescription: MetaSchema = {
   name: 'twitter:description',
-  key: 'property',
+  key: 'name',
   type: 'twitter',
   color: '#1DA1F2',
   tags: 'social-share',

--- a/packages/db/src/meta/en/twitter:image.ts
+++ b/packages/db/src/meta/en/twitter:image.ts
@@ -2,7 +2,8 @@ import type { MetaSchema } from '../../metaFlat'
 
 export const twitterImage: MetaSchema = {
   name: 'twitter:image',
-  key: 'property',
+  key: 'name',
+  type: 'twitter',
   color: '#1DA1F2',
   tags: 'social-share',
   description: 'Specifies the URL of the image to be displayed in tweets when a web page is shared on Twitter. The image should have a minimum size of 120x120px and a maximum size of 4096x4096px.',

--- a/packages/db/src/meta/en/twitter:image:alt.ts
+++ b/packages/db/src/meta/en/twitter:image:alt.ts
@@ -3,6 +3,7 @@ import type { MetaSchema } from '../../metaFlat'
 export const twitterImageAlt: MetaSchema = {
   name: 'twitter:image:alt',
   key: 'name',
+  type: 'twitter',
   color: '#FFDD85',
   tags: 'social-share',
   description: 'Specifies the alternative text for an image when shared on Twitter. Alternative text provides a text description of the image for users who can\'t see it, such as those using screen readers or with slow internet connections.',

--- a/packages/db/src/meta/en/twitter:image:height.ts
+++ b/packages/db/src/meta/en/twitter:image:height.ts
@@ -3,6 +3,7 @@ import type { MetaSchema } from '../../metaFlat'
 export const twitterImageHeight: MetaSchema = {
   name: 'twitter:image:height',
   key: 'name',
+  type: 'twitter',
   color: '#FFAC33',
   tags: 'social-share',
   description: 'Specifies the height of the image to be displayed when a web page is shared on Twitter. It is used by Twitter to properly display the image in the tweet.',

--- a/packages/db/src/meta/en/twitter:image:type.ts
+++ b/packages/db/src/meta/en/twitter:image:type.ts
@@ -3,6 +3,7 @@ import type { MetaSchema } from '../../metaFlat'
 export const twitterImageType: MetaSchema = {
   name: 'twitter:image:type',
   key: 'name',
+  type: 'twitter',
   description: 'Specifies the type of the image referenced in the "twitter:image" meta tag. This meta tag is used to define the type of image file that is being shared on Twitter.',
   tags: 'social-share',
   color: '#FFB536',

--- a/packages/db/src/meta/en/twitter:image:width.ts
+++ b/packages/db/src/meta/en/twitter:image:width.ts
@@ -3,6 +3,7 @@ import type { MetaSchema } from '../../metaFlat'
 export const twitterImageWidth: MetaSchema = {
   name: 'twitter:image:width',
   key: 'name',
+  type: 'twitter',
   color: '#FF8C42',
   tags: 'social-share',
   description: 'Specifies the width of the image to be displayed when sharing a web page on Twitter.',

--- a/packages/db/src/meta/en/twitter:label2.ts
+++ b/packages/db/src/meta/en/twitter:label2.ts
@@ -2,7 +2,8 @@ import type { MetaSchema } from '../../metaFlat'
 
 export const twitterLabel2: MetaSchema = {
   name: 'twitter:label2',
-  key: 'property',
+  key: 'name',
+  type: 'twitter',
   description: 'Custom label for the second value of a Twitter card.',
   tags: 'social-share',
   color: '#FFA500',

--- a/packages/db/src/meta/en/twitter:player.ts
+++ b/packages/db/src/meta/en/twitter:player.ts
@@ -3,6 +3,7 @@ import type { MetaSchema } from '../../metaFlat'
 export const twitterPlayer: MetaSchema = {
   name: 'twitter:player',
   key: 'name',
+  type: 'twitter',
   color: '#1DA1F2',
   tags: 'social-share',
   description: 'Specifies the URL to a Twitter card player that should be used when the URL in the "twitter:card" meta tag is set to "player".',

--- a/packages/db/src/meta/en/twitter:player:stream.ts
+++ b/packages/db/src/meta/en/twitter:player:stream.ts
@@ -3,6 +3,7 @@ import type { MetaSchema } from '../../metaFlat'
 export const twitterPlayerStream: MetaSchema = {
   name: 'twitter:player:stream',
   key: 'name',
+  type: 'twitter',
   color: '#00ACEE',
   tags: 'social-share',
   description: 'Specifies the URL to a live video stream on Twitter. When shared on Twitter, this meta tag allows the video player to display and play the live stream directly in the tweet.',

--- a/packages/db/src/meta/en/twitter:player:width.ts
+++ b/packages/db/src/meta/en/twitter:player:width.ts
@@ -3,6 +3,7 @@ import type { MetaSchema } from '../../metaFlat'
 export const twitterPlayerWidth: MetaSchema = {
   name: 'twitter:player:width',
   key: 'name',
+  type: 'twitter',
   color: '#FFB30D',
   tags: 'social-share',
   description: 'Specifies the width of the Twitter card player on a web page when shared on Twitter. The Twitter card player allows users to play video or audio content directly within a tweet.',

--- a/packages/db/src/meta/en/twitter:site:id.ts
+++ b/packages/db/src/meta/en/twitter:site:id.ts
@@ -3,6 +3,7 @@ import type { MetaSchema } from '../../metaFlat'
 export const twitterSiteId: MetaSchema = {
   name: 'twitter:site:id',
   key: 'name',
+  type: 'twitter',
   color: '#1DA1F2',
   tags: 'social-share',
   description: 'Specifies the Twitter username associated with the website or content.',

--- a/packages/db/src/meta/en/twitter:title.ts
+++ b/packages/db/src/meta/en/twitter:title.ts
@@ -3,6 +3,7 @@ import type { MetaSchema } from '../../metaFlat'
 export const twitterTitle: MetaSchema = {
   name: 'twitter:title',
   key: 'name',
+  type: 'twitter',
   color: '#33CCFF',
   tags: 'social-share',
   description: 'Specifies the title of a webpage when shared on Twitter. It is used to provide a concise and compelling title that grabs users\' attention and encourages engagement.',

--- a/packages/db/src/metaFlat.ts
+++ b/packages/db/src/metaFlat.ts
@@ -23,6 +23,7 @@ import { creator } from './meta/en/creator'
 import { defaultStyle } from './meta/en/default-style'
 import { description } from './meta/en/description'
 import { fbAppId } from './meta/en/fb:app_id'
+import { fediverseCreator } from './meta/en/fediverse:creator'
 import { formatDetection } from './meta/en/format-detection'
 import { generator } from './meta/en/generator'
 import { google } from './meta/en/google'
@@ -142,6 +143,7 @@ export const metaFlatSchema: Record<keyof MetaFlat, MetaSchema> = {
   defaultStyle,
   description,
   fbAppId,
+  fediverseCreator,
   formatDetection,
   generator,
   google,

--- a/packages/zhead/src/meta.ts
+++ b/packages/zhead/src/meta.ts
@@ -15,6 +15,7 @@ export type MetaNames =
   'default-style' |
   'description' |
   'fb:app_id' |
+  'fediverse:creator' |
   'format-detection' |
   'generator' |
   'google-site-verification' |

--- a/packages/zhead/src/metaFlat.ts
+++ b/packages/zhead/src/metaFlat.ts
@@ -612,6 +612,13 @@ export interface MetaFlat extends MetaFlatArticle, MetaFlatBook, MetaFlatProfile
    * @see https://developers.facebook.com/docs/sharing/webmasters#basic
    */
   fbAppId: string | number
+  /**
+   * Indicates the Fediverse account of the content creator or author.
+   *
+   * @example '@gargron@mastodon.social'
+   * @see https://blog.joinmastodon.org/2024/07/highlighting-journalism-on-mastodon/
+   */
+  fediverseCreator: string
   // Twitter meta
   /**
    * The card type


### PR DESCRIPTION
## Summary
- Add `fediverse:creator` meta tag support (type definition, MetaFlat property, db schema). Closes #26
- Add missing `type: 'twitter'` to 24 twitter meta tag db entries that lacked categorization. Closes #27
- Fix `key: 'property'` to `key: 'name'` on `twitter:description`, `twitter:image`, and `twitter:label2` (twitter tags use `<meta name="">` not `<meta property="">`)

## Test plan
- [x] `pnpm build` passes